### PR TITLE
Chemical detector fix

### DIFF
--- a/core/fnc/chem/ehDetector.sqf
+++ b/core/fnc/chem/ehDetector.sqf
@@ -26,7 +26,7 @@ Author:
         params ["_display", "_key"];
 
         if (
-            _key in actionKeys "Watch" &&
+            (_key in actionKeys "Watch" || _key in actionKeys "WatchToggle") &&
             {!visibleWatch} &&
             {"ChemicalDetector_01_watch_F" in (assignedItems player)}
         ) then {


### PR DESCRIPTION
Fixed chemical detector not updating if the user used the "watchToggle" without triggering the "watch" action.

This has been tested and confirmed to work on localhosted server.